### PR TITLE
Sane defaults for FullWidthTheme and CenterTheme

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -7,7 +7,7 @@
   {{ partial "head.html" . }}
 </head>
 <body class="{{- ( or .Params.color $.Site.Params.ThemeColor ) -}}">
-{{ $container := cond $.Site.Params.FullWidthTheme "container full" (cond $.Site.Params.CenterTheme "container center" "container") }}
+{{ $container := cond ($.Site.Params.FullWidthTheme | default false) "container full" (cond ($.Site.Params.CenterTheme | default true) "container center" "container") }}
 
 <div class="{{- $container -}}{{- cond ($.Site.Params.oneHeadingSize | default true) " headings--one-size" "" }}">
 


### PR DESCRIPTION
Providing sane defaults in order to use the template with no additional configuration at all.

At the moment you can't just do
```
hugo new site mysyte
cd mysyte
git init
git submodule add https://github.com/panr/hugo-theme-terminal.git themes/terminal
hugo server -t terminal
```
because FullWitdthTheme and CentralTheme params are not set.
```
themes/terminal/layouts/_default/baseof.html:10:23": execute of template failed: template: _default/terms.html:10:23: executing "_default/terms.html" at <$.Site.Params.FullWidthTheme>: invalid value; expected bool
```

With this little fix the theme starts with no additional configuration than the standard one created by hugo cli.